### PR TITLE
HostKeyAlgorithms: add rsa-sha2-256 and rsa-sha2-512 for ssh-rsa

### DIFF
--- a/knownhosts_test.go
+++ b/knownhosts_test.go
@@ -42,10 +42,10 @@ func TestHostKeyAlgorithms(t *testing.T) {
 	}
 
 	expectedAlgorithms := map[string][]string{
-		"only-rsa.example.test:22":     {"ssh-rsa"},
+		"only-rsa.example.test:22":     {"rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"},
 		"only-ecdsa.example.test:22":   {"ecdsa-sha2-nistp256"},
 		"only-ed25519.example.test:22": {"ssh-ed25519"},
-		"multi.example.test:2233":      {"ssh-rsa", "ecdsa-sha2-nistp256", "ssh-ed25519"},
+		"multi.example.test:2233":      {"rsa-sha2-512", "rsa-sha2-256", "ssh-rsa", "ecdsa-sha2-nistp256", "ssh-ed25519"},
 		"192.168.1.102:2222":           {"ecdsa-sha2-nistp256", "ssh-ed25519"},
 		"unknown-host.example.test":    {}, // host not in file
 		"multi.example.test:22":        {}, // different port than entry in file


### PR DESCRIPTION
- Related to https://github.com/trzsz/trzsz-ssh/issues/93

- Steps to reproduce:
  - Change `/etc/ssh/sshd_config` on the ssh server, add a configuration:
    ```
    HostKeyAlgorithms rsa-sha2-512,rsa-sha2-256
    ```
  - Restart the ssh server `service ssh restart`.
  - Delete the known host items of the server in `~/.ssh/known_hosts` on the client.
  - Log in to the server using go ssh client, which should add a `ssh-rsa` item to `~/.ssh/known_hosts`.
  - Log in to the server using go ssh client again, an error will occur:
    ```
    client offered: [ssh-rsa], server offered: [rsa-sha2-512 rsa-sha2-256]
    ````